### PR TITLE
bare minimum changes to get working on gcc 11.3.0 -warning but building.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.settings
+.cproject
+.project
+skipfish

--- a/src/analysis.c
+++ b/src/analysis.c
@@ -328,7 +328,7 @@ static u8* html_decode_param(u8* url, u8 also_js) {
    _store, NULL if not found). Buffer needs to be NUL-terminated
    at nearest >.  The macro supports the "name\s*=aaa" cases.  */
 
-#define FIND_AND_MOVE(_store, _val, _param) { \
+#define FIND_AND_MOVE(_store, _val, _param) do { \
     (_store) = inl_strcasestr((u8*)_val, (u8*)_param); \
     if (_store) { \
       if (!isspace((_store)[-1])) { \

--- a/src/http_client.c
+++ b/src/http_client.c
@@ -89,8 +89,8 @@ u64 bytes_sent,
     bytes_inflated,
     iterations_cnt = 0;
 
-u8 *auth_user,
-   *auth_pass;
+u8 *http_client_auth_user,
+   *http_client_auth_pass;
 
 
 #ifdef PROXY_SUPPORT
@@ -1058,10 +1058,10 @@ u8* build_request_data(struct http_request* req) {
   /* Take care of HTTP authentication next. */
 
   if (auth_type == AUTH_BASIC) {
-    u8* lp = ck_alloc(strlen((char*)auth_user) + strlen((char*)auth_pass) + 2);
+    u8* lp = ck_alloc(strlen((char*)http_client_auth_user) + strlen((char*)http_client_auth_pass) + 2);
     u8* lpb64;
 
-    sprintf((char*)lp, "%s:%s", auth_user, auth_pass);
+    sprintf((char*)lp, "%s:%s", http_client_auth_user, http_client_auth_pass);
 
     lpb64 = b64_encode(lp, strlen((char*)lp));
 
@@ -1915,6 +1915,8 @@ void async_request(struct http_request* req) {
 
 }
 
+// TODO FIX!!!
+#if 0
 /* A helper function to compare the CN / altname with our host name */
 
 static u8 match_cert_name(char* req_host, char* host) {
@@ -1947,6 +1949,7 @@ static u8 match_cert_name(char* req_host, char* host) {
 
   return 1;
 }
+#endif
 
 
 /* Check SSL properties, raise security alerts if necessary. We do not perform
@@ -1957,6 +1960,8 @@ static u8 match_cert_name(char* req_host, char* host) {
    We might eventually want to check aliases or support TLS SNI. */
 
 static void check_ssl(struct conn_entry* c) {
+// TODO FIX!!!
+#if 0
   X509 *p;
   const SSL_CIPHER *cp;
 
@@ -2053,7 +2058,7 @@ static void check_ssl(struct conn_entry* c) {
 
   } else problem(PROB_SSL_NO_CERT, c->q->req, 0, 0,
                  host_pivot(c->q->req->pivot), 0);
-
+#endif
   c->ssl_checked = 1;
 }
 

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -454,8 +454,8 @@ extern u8 browser_type;
 
 extern u8 auth_type;
 
-extern u8 *auth_user,
-          *auth_pass;
+extern u8 *http_client_auth_user,
+          *http_client_auth_pass;
 
 #ifdef PROXY_SUPPORT
 extern u8* use_proxy;

--- a/src/report.c
+++ b/src/report.c
@@ -444,7 +444,7 @@ static void collect_samples(struct http_request *req, struct http_response *res)
 
   if (!req->pivot->dupe && res->sniffed_mime) {
 
-    for (i=0;i<m_samp_cnt;i++)
+    for (i=0;i<m_samp_cnt;i++) {
       if (!strcmp((char*)m_samp[i].det_mime, (char*)res->sniffed_mime)) break;
 
       if (i == m_samp_cnt) {
@@ -457,8 +457,9 @@ static void collect_samples(struct http_request *req, struct http_response *res)
       /* If we already have something that looks very much the same on the
          list, don't bother reporting it again. */
 
-        for (c=0;c<m_samp[i].sample_cnt;c++)
+        for (c=0;c<m_samp[i].sample_cnt;c++) {
           if (same_page(&m_samp[i].res[c]->sig, &res->sig)) return;
+        }
       }
 
       m_samp[i].req = ck_realloc(m_samp[i].req, (m_samp[i].sample_cnt + 1) *
@@ -468,7 +469,7 @@ static void collect_samples(struct http_request *req, struct http_response *res)
       m_samp[i].req[m_samp[i].sample_cnt] = req;
       m_samp[i].res[m_samp[i].sample_cnt] = res;
       m_samp[i].sample_cnt++;
-
+    }
   }
 }
 

--- a/src/signatures.h
+++ b/src/signatures.h
@@ -80,10 +80,10 @@ void destroy_signature_lists(void);
 void signature_problem(struct signature *sig, struct http_request *req, struct http_response *res);
 
 
-struct signature** sig_list;       /* The one and only: signature list       */
+extern struct signature** sig_list;       /* The one and only: signature list       */
 
 extern u32 slist_max_cnt;          /* Allocated space in the signature lists */
-u32 slist_cnt;                     /* Actual elements in the signature lists */
+extern u32 slist_cnt;                     /* Actual elements in the signature lists */
 
 #define TYPE_PLAIN 0               /* Content type: static string            */
 #define TYPE_REGEX 1               /* Content type: regular expression       */


### PR DESCRIPTION
### What
Bare minimum changes to get back to building (warning, but building) w/ `gcc 11.3.0`

- Multiple definitions
```sh
/usr/bin/ld: /tmp/ccN6Npml.o:/home/rmorrison/gproj/skipfish/src/signatures.h:86: multiple definition of `slist_cnt'; /tmp/ccWB7eFE.o:/home/rmorrison/gproj/skipfish/src/signatures.h:86: first defined here
/usr/bin/ld: /tmp/ccN6Npml.o:/home/rmorrison/gproj/skipfish/src/signatures.h:83: multiple definition of `sig_list'; /tmp/ccWB7eFE.o:/home/rmorrison/gproj/skipfish/src/signatures.h:83: first defined here
/usr/bin/ld: /tmp/ccBkmLsQ.o:/home/rmorrison/gproj/skipfish/src/signatures.h:86: multiple definition of `slist_cnt'; /tmp/ccWB7eFE.o:/home/rmorrison/gproj/skipfish/src/signatures.h:86: first defined here
/usr/bin/ld: /tmp/ccBkmLsQ.o:/home/rmorrison/gproj/skipfish/src/signatures.h:83: multiple definition of `sig_list'; /tmp/ccWB7eFE.o:/home/rmorrison/gproj/skipfish/src/signatures.h:83: first defined here
```
Moved most of these to single externs declared in headers but instantiated or defined once in the implementation files (*.c)

- Commented out deprecated usages of OpenSSL data structures (`SSL_CIPHER`/`X509`).  As of OpenSSL 1.1.x+ a lot of structures treated as opaque (void*) from the library user's perspective.  Need to use accessor functions to grab state information.
```sh
src/http_client.c:1965:10: error: invalid use of incomplete typedef ‘SSL_CIPHER’ {aka ‘const struct ssl_cipher_st’}
 1965 |   if(!(cp->algo_strength & SSL_MEDIUM) && !(cp->algo_strength & SSL_HIGH))
      |          ^~
src/http_client.c:1965:47: error: invalid use of incomplete typedef ‘SSL_CIPHER’ {aka ‘const struct ssl_cipher_st’}
 1965 |   if(!(cp->algo_strength & SSL_MEDIUM) && !(cp->algo_strength & SSL_HIGH))
      |                                               ^~
src/http_client.c:1982:34: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 1982 |     if (ASN1_UTCTIME_cmp_time_t(p->cert_info->validity->notBefore, cur_time)
      |                                  ^~
src/http_client.c:1984:34: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 1984 |         ASN1_UTCTIME_cmp_time_t(p->cert_info->validity->notAfter, cur_time)
      |                                  ^~
src/http_client.c:1991:33: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 1991 |     issuer = X509_NAME_oneline(p->cert_info->issuer,NULL,0);
      |                                 ^~
src/http_client.c:1993:22: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 1993 |     if (!issuer || !p->name || !strcmp(issuer, p->name))
      |                      ^~
src/http_client.c:1993:49: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 1993 |     if (!issuer || !p->name || !strcmp(issuer, p->name))
      |                                                 ^~
src/http_client.c:2006:21: error: invalid use of incomplete typedef ‘X509’ {aka ‘struct x509_st’}
 2006 |     host = strrchr(p->name, '=');
      |                     ^~

```
Commented out and marked as `TODO` fix in a later PR.

- Fixed some bracing
```
src/report.c: In function ‘collect_samples’:
src/report.c:447:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
  447 |     for (i=0;i<m_samp_cnt;i++)
      |     ^~~
src/report.c:450:7: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
  450 |       if (i == m_samp_cnt) {
      |       ^~
```

I might not totally grok the logic, but this may be a real bug that'll affect reporting.

```
src/analysis.c:491:9: note: in expansion of macro ‘FIND_AND_MOVE’
  491 |         FIND_AND_MOVE(tag_value, cur_str, "value");
      |         ^~~~~~~~~~~~~
src/analysis.c:331:45: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘while’
  331 | #define FIND_AND_MOVE(_store, _val, _param) { \
      |                                             ^
src/analysis.c:492:9: note: in expansion of macro ‘FIND_AND_MOVE’
  492 |         FIND_AND_MOVE(tag_type, cur_str, "type");
      |         ^~~~~~~~~~~~~
src/analysis.c: In function ‘make_form_req’:
src/analysis.c:343:4: warning: this ‘while’ clause does not guard... [-Wmisleading-indentation]
  343 |  } while (0)
      |    ^~~~~
```

Missing `do ` preceding `do { ... } while(0)` guard in proprocessor macro.

